### PR TITLE
Adds ability to specify vimeo iframe URL parameters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 Interface props {
     videoId: String,
     className?: String = 'vimeo',
+    playerOptions?: Object = { autoplay: 1 },
     onReady?(data?: Object) => Void,
     onCuechange?(data?: Object) => Void,
     onError?(data?: Object) => Void,
@@ -22,6 +23,9 @@ The Vimeo video ID
 
 ## className: String
 `className` applied to wrapping div
+
+## playerOptions: Object
+Object of player options as specified in Vimeo Player docs: https://developer.vimeo.com/player/embedding#universal-parameters. Will get appended to iframe URL
 
 ## onReady?(data: Object) => Void
 Called when video has loaded and is ready to play.

--- a/src/Vimeo.jsx
+++ b/src/Vimeo.jsx
@@ -51,7 +51,8 @@ export default React.createClass({
     onReady: PropTypes.func,
     onSeek: PropTypes.func,
     playButton: PropTypes.node,
-    videoId: PropTypes.string.isRequired
+    videoId: PropTypes.string.isRequired,
+    playerOptions: PropTypes.object
   },
 
   getDefaultProps() {
@@ -63,6 +64,7 @@ export default React.createClass({
       }, {});
 
     defaults.className = 'vimeo';
+    defaults.playerOptions = { autoplay: 1 };
     return defaults;
   },
 
@@ -168,7 +170,15 @@ export default React.createClass({
   },
 
   getIframeUrl() {
-    return `//player.vimeo.com/video/${this.props.videoId}?autoplay=1`;
+    return `//player.vimeo.com/video/${this.props.videoId}?${this.getIframeUrlQuery()}`;
+  },
+
+  getIframeUrlQuery() {
+    let str = [];
+    Object.keys(this.props.playerOptions).forEach(key => {
+      str.push(`${key}=${this.props.playerOptions[key]}`);
+    });
+    return str.join("&");
   },
 
   fetchVimeoData() {


### PR DESCRIPTION
Ive added the ability to specify player options for the iframe URL, as outlined here https://developer.vimeo.com/player/embedding#universal-parameters. 

Should solve some of the requests here: https://github.com/FreeCodeCamp/react-vimeo/issues/1

Waiting on https://github.com/FreeCodeCamp/react-vimeo/pull/9
