### PR TITLE
Fix(build): update banner usage of lodash template

### DIFF
--- a/banner.js
+++ b/banner.js
@@ -1,4 +1,4 @@
-module.exports = require('lodash').template([
+module.exports = require('lodash/template')([
   '/*',
   ' * React-Vimeo - <%= pkg.description %>',
   ' * @version v<%= pkg.version %>',
@@ -6,6 +6,6 @@ module.exports = require('lodash').template([
   ' * @license <%= pkg.license %>',
   ' * @author <%= pkg.author.name %> (<%= pkg.author.url %>)',
   '*/\n'
-].join('\n'), {
+].join('\n'))({
   pkg: require('./package.json')
 });


### PR DESCRIPTION
The API of the lodash template function has changed
causing webpack to fail while building the UMD files.
This PR updates the banner.js file to use the new
API;

closes #21
